### PR TITLE
Add support for public key PEM-to-XML conversion

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,22 +5,44 @@ using System.Xml;
 Console.WriteLine("PEM to XML RSA Key Converter started...");
 
 string? filename = "";
+string? keySelection = "";
+
 if (args.Length > 0)
     filename = args[0];
 else
 {
+    Console.WriteLine("Please choose private key (Press 0) OR public key (Press 1):");
+    keySelection = Console.ReadLine();
+
     Console.WriteLine("Please enter PEM filename:");
     filename = Console.ReadLine();
 }
 
 if (!String.IsNullOrEmpty(filename))
-{
-    var privateKey = await File.ReadAllTextAsync(filename);
-    var rsa = RSA.Create();
-    rsa.ImportFromPem(privateKey.ToCharArray());
-    var d = new XmlDocument();
-    d.LoadXml(rsa.ToXmlString(true));
+    // Use for public key
+    if (keySelection == "1")
+    {
+        var publicKeyPem = await File.ReadAllTextAsync(filename);
+        // Remove headers and footers
+        publicKeyPem = publicKeyPem.Replace("-----BEGIN PUBLIC KEY-----", "").Replace("-----END PUBLIC KEY-----", "").Trim();
+        var publicKeyBytes = Convert.FromBase64String(publicKeyPem);
+        var rsa = RSA.Create();
+        rsa.ImportSubjectPublicKeyInfo(publicKeyBytes, out _);
+        var d = new XmlDocument();
+        d.LoadXml(rsa.ToXmlString(false)); // false to get only the public key
 
-    var xmlFilename = filename.EndsWith(".pem") ? filename.Replace(".pem", ".xml") : filename + ".xml";
-    d.Save(xmlFilename);
-}
+        var xmlFilename = filename.EndsWith(".pem") ? filename.Replace(".pem", ".xml") : filename + ".xml";
+        d.Save(xmlFilename);
+    }
+    // In case of private key
+    else if (keySelection == "0")
+    {
+        var privateKey = await File.ReadAllTextAsync(filename);
+        var rsa = RSA.Create();
+        rsa.ImportFromPem(privateKey.ToCharArray());
+        var d = new XmlDocument();
+        d.LoadXml(rsa.ToXmlString(true));
+
+        var xmlFilename = filename.EndsWith(".pem") ? filename.Replace(".pem", ".xml") : filename + ".xml";
+        d.Save(xmlFilename);
+    }


### PR DESCRIPTION
This commit allow user to select between public key and private key PEM-to-XML conversion, which is not supported in the main repository.